### PR TITLE
Fix small space typo in the .urdf file

### DIFF
--- a/urdf/VISPA_modifiedDH_Ros2.urdf
+++ b/urdf/VISPA_modifiedDH_Ros2.urdf
@@ -40,7 +40,7 @@
     </visual>
     <inertial>
       <mass value="3.995"/>
-      <inertia ixx="0.010 " ixy="0" ixz="0" iyy="0.578" iyz="0" izz="0.574"/>
+      <inertia ixx="0.010" ixy="0" ixz="0" iyy="0.578" iyz="0" izz="0.574"/>
       <origin xyz="0.4 0 0.142"/>
     </inertial>
   </link>
@@ -119,7 +119,7 @@
     <child link="Link_1"/>
     <axis xyz="0 0 1"/>
     <limit effort="50" lower="-3.14149265359" upper="3.14149265359" velocity="0.09395689"/>
-    <origin xyz="0 0 0.18" rpy="0 0 0"/> 
+    <origin xyz="0 0 0.18" rpy="0 0 0"/>
   </joint>
 
   <joint name="Joint_2" type="revolute">
@@ -127,7 +127,7 @@
     <child link="Link_2"/>
     <axis xyz="0 0 1"/>
     <limit effort="50" lower="-3.14149265359" upper="3.14149265359" velocity="0.09395689"/>
-    <origin xyz="0 0 0" rpy="1.57079632679 -1.57079632679 0"/> 
+    <origin xyz="0 0 0" rpy="1.57079632679 -1.57079632679 0"/>
   </joint>
 
   <joint name="Joint_3" type="revolute">
@@ -135,7 +135,7 @@
     <child link="Link_3"/>
     <axis xyz="0 0 1"/>
     <limit effort="50" lower="-3.14149265359" upper="3.14149265359" velocity="0.09395689"/>
-    <origin xyz="0.8 0 0" rpy="0 0 -1.57079632679"/> 
+    <origin xyz="0.8 0 0" rpy="0 0 -1.57079632679"/>
   </joint>
 
   <joint name="Joint_4" type="revolute">
@@ -143,7 +143,7 @@
     <child link="Link_4"/>
     <axis xyz="0 0 1"/>
     <limit effort="50" lower="-3.14149265359" upper="3.14149265359" velocity="0.09395689"/>
-    <origin xyz="0 0.65 0" rpy="-1.57079632679 0 0"/> 
+    <origin xyz="0 0.65 0" rpy="-1.57079632679 0 0"/>
   </joint>
 
   <joint name="Joint_5" type="revolute">
@@ -151,7 +151,7 @@
     <child link="Link_5"/>
     <axis xyz="0 0 1"/>
     <limit effort="50" lower="-3.14149265359" upper="3.14149265359" velocity="0.09395689"/>
-    <origin xyz="0 0 0" rpy="1.57079632679 0 0"/> 
+    <origin xyz="0 0 0" rpy="1.57079632679 0 0"/>
   </joint>
 
   <joint name="Joint_6" type="revolute">
@@ -159,7 +159,7 @@
     <child link="Link_6"/>
     <axis xyz="0 0 1"/>
     <limit effort="50" lower="-3.14149265359" upper="3.14149265359" velocity="0.09395689"/>
-    <origin xyz="0 0.325 0" rpy="-1.57079632679 0 0"/> 
+    <origin xyz="0 0.325 0" rpy="-1.57079632679 0 0"/>
   </joint>
 
 </robot>


### PR DESCRIPTION
Hello,

There is a small space typo in the [urdf](https://github.com/AirbusDefenceAndSpace/vispa/blob/0947ec31c4215b0fa3d2af2006270b6b1f2fa63f/urdf/VISPA_modifiedDH_Ros2.urdf) file (line 43). Other changes are just my IDE automatically removing trailing whitespaces.
Launching the urdf without the changes gives:
![image](https://github.com/AirbusDefenceAndSpace/vispa/assets/8035162/3e18da18-ed5e-45fb-a347-55c912854dda)

---

With the fixes:

![image](https://github.com/AirbusDefenceAndSpace/vispa/assets/8035162/e09754c4-1fff-4a3c-aafd-484bd325ba17)

---

By the way, I am wondering if the lower/upper values are correct?

```
     <parent link="Link_0"/>
     <child link="Link_1"/>
     <axis xyz="0 0 1"/>
-    <limit effort="50" lower="-3.14149265359" upper="3.14149265359" velocity="0.09395689"/>
+    <limit effort="50" lower="-3.14159265359" upper="3.14159265359" velocity="0.09395689"/>
     <origin xyz="0 0 0.18" rpy="0 0 0"/>
   </joint>
```

If they are PI values, all the `3.14149265359` should be replaced with `3.14159265359` I guess?